### PR TITLE
Update diskspace_telegram_notification.py

### DIFF
--- a/Code-Snippets/diskspace_telegram_notification.py
+++ b/Code-Snippets/diskspace_telegram_notification.py
@@ -10,7 +10,7 @@ Telegram_Chat_ID = ''
 Nodeaddress = ''
 
 
-#Atlas = 0 , Apollo = 1
+#Atlas = 0 , Apollo = 1 , Hermes = 2
 Nodetype = '0'
 
 
@@ -56,7 +56,13 @@ if Nodetype == '0':
     Nodename = ('Atlas Node '+Nodenumber)
     if float(free) <= float(freeSpaceTreshold):
         send_message(lowSpace+" Your "+Nodename+" is running low on free disk space with "+free+" gigabytes remaining.\nPlease upgrade this Nodes SSD:\n<a href=\"https://explorer.ambrosus.com/apollo/"+Nodeaddress+"\">"+Nodeaddress+"</a>\n\n-------------------------------")
-else:
+elif Nodetype == '1':
     Nodename = ('Apollo Node '+Nodenumber)
-    if free <= freeSpaceTreshold:
+    if float(free) <= float(freeSpaceTreshold):
         send_message(lowSpace+" Your "+Nodename+" is running low on free disk space with "+free+" gigabytes remaining.\nPlease upgrade this Nodes SSD:\n<a href=\"https://explorer.ambrosus.com/apollo/"+Nodeaddress+"\">"+Nodeaddress+"</a>\n\n-------------------------------")
+elif Nodetype == '2':
+    Nodename = ('Hermes Node '+Nodenumber)
+    if float(free) <= float(freeSpaceTreshold):
+        send_message(lowSpace+" Your "+Nodename+" is running low on free disk space with "+free+" gigabytes remaining.\nPlease upgrade this Nodes SSD:\n<a href=\"https://explorer.ambrosus.com/apollo/"+Nodeaddress+"\">"+Nodeaddress+"</a>\n\n-------------------------------")
+else:
+    send_message("You specified an unknown Node type for your Node with Address \n<a href=\"https://explorer.ambrosus.com/apollo/"+Nodeaddress+"\">"+Nodeaddress+"</a>. \nPlease update the notification script with a valid node type\n\n-------------------------------")


### PR DESCRIPTION
The test free <= freeSpaceTreshold (where free>freeSpaceTreshold) had different results on different machines. I can't explain why in the world it gave True on some machines and False on others, but converting the numbers to float seems to fix it. All machines had the same python3 version installed.

Additionally I added the possibility to define a hermes node and to catch a invalid Nodetype.